### PR TITLE
exercism演習(OpenStruct)

### DIFF
--- a/works/october/1030/boutique-inventory-improvements/README.md
+++ b/works/october/1030/boutique-inventory-improvements/README.md
@@ -1,0 +1,115 @@
+# Boutique Inventory Improvements
+
+Welcome to Boutique Inventory Improvements on Exercism's Ruby Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Introduction
+
+`OpenStruct` allows you to easily create an object from a `Hash`. 
+Rather than having to access using `Hash` keys, `OpenStruct` instead allows us to use methods to access and set values.
+
+
+```ruby
+attributes = { name: "Jeremy Walker", age: 21, location: "Nomadic" }
+person = OpenStruct.new(attributes)
+
+person.name
+#=> Jeremy Walker
+
+person.location
+#=> Nomadic
+
+# Update the age
+person.age = 35
+
+# It sets correctly
+person.age
+#=> 35
+```
+
+One bonus to this approach is that we can take advantage of a shortcut when using block syntax. 
+In situations where a block calls a single method, you can replace the block with `&:` followed by the method name. 
+For example, these two lines are synonymous:
+
+```ruby
+people.sum { |person| person.age }
+people.sum(&:age)
+```
+
+## Standard Library
+
+All of the classes you've seen in previous exercises have been part of Ruby's Core Library.
+
+OpenStruct is part of Ruby's Standard Library (often shortened to "stdlib") - a collection of classes for working with things such as dates, json, and networking.
+It also provides some useful functionality for making your code easier to work with.
+
+When using classes that are not from the Core Library — your own code in different files, classes from stdlib, or external dependencies — we need to import them using the `require` method before we can use them.
+For example:
+
+```ruby
+require 'ostruct'
+
+person = OpenStruct.new(name: "Jeremy Walker")
+# ...
+```
+
+## Instructions
+
+You're continuing to work on the stock management system you built previously. Since discovering `OpenStruct` and block shortcuts, you've decided to refactor the code a little. Rather than storing the items as hashes, you're going to utilize your newfound skills.
+
+## 1. Allow retrievable of items
+
+You want to continue to retrieve the list of items in stock, but this time they should be objects that can have methods called on them.
+
+```ruby
+inventory = BoutiqueInventory.new([
+  {price: 65.00, name: "Maxi Brown Dress", quantity_by_size: {s: 3, m: 7, l: 8, xl: 4}},
+  {price: 50.00, name: "Red Short Skirt", quantity_by_size: {}},
+  {price: 29.99, name: "Black Short Skirt", quantity_by_size: {s: 1, xl: 4}},
+  {price: 20.00, name: "Bamboo Socks Cats", quantity_by_size: {s: 7, m: 2}}
+])
+
+inventory.items.first.name
+# => "Maxi Brown Dress"
+
+inventory.items.first.price
+# => 65
+
+inventory.items.size
+# => 4
+```
+
+Refactor `item_names` to use the new block shortcut you've learnt rather than hashes.
+As a reminder, the method should return:
+
+```ruby
+BoutiqueInventory.new([
+  {price: 65.00, name: "Maxi Brown Dress", quantity_by_size: {s: 3, m: 7, l: 8, xl: 4}},
+  {price: 50.00, name: "Red Short Skirt", quantity_by_size: {}},
+  {price: 29.99, name: "Black Short Skirt", quantity_by_size: {s: 1, xl: 4}},
+  {price: 20.00, name: "Bamboo Socks Cats", quantity_by_size: {s: 7, m: 2}}
+]).item_names
+
+# => ["Bamboo Socks Cats", "Black Short Skirt", "Maxi Brown Dress", "Red Short Skirt"]
+```
+
+
+Refactor `total_stock` to use the new block shortcut you've learnt rather than hashes.
+As a reminder, the method should return::
+
+```ruby
+BoutiqueInventory.new([
+  {price: 65.00, name: "Maxi Brown Dress", quantity_by_size: {s: 3, m: 7, l: 8, xl: 4}},
+  {price: 50.00, name: "Red Short Skirt", quantity_by_size: {}},
+  {price: 29.99, name: "Black Short Skirt", quantity_by_size: {s: 1, xl: 4}},
+  {price: 20.00, name: "Bamboo Socks Cats", quantity_by_size: {s: 7, m: 2}}
+]).total_stock
+
+# => 36
+```
+
+## Source
+
+### Created by
+
+- @iHiD

--- a/works/october/1030/boutique-inventory-improvements/boutique_inventory.rb
+++ b/works/october/1030/boutique-inventory-improvements/boutique_inventory.rb
@@ -1,0 +1,17 @@
+class BoutiqueInventory
+  attr_reader :items
+
+  def initialize(items)
+    @items = items.map { |item| OpenStruct.new(item) }
+  end
+
+  def item_names
+    items.map { |item| item.name }.sort
+  end
+
+  def total_stock
+    items.sum do |item|
+      item.quantity_by_size.values.sum
+    end
+  end
+end

--- a/works/october/1030/boutique-inventory-improvements/boutique_inventory_test.rb
+++ b/works/october/1030/boutique-inventory-improvements/boutique_inventory_test.rb
@@ -1,0 +1,54 @@
+require 'minitest/autorun'
+require_relative 'boutique_inventory'
+
+class BoutiqueInventoryTest < Minitest::Test
+  def test_no_item_names
+    assert_empty BoutiqueInventory.new([]).item_names
+  end
+
+  def test_one_item_name
+    items = [
+      { price: 65.00, name: "Red Brown Dress", quantity_by_size: {} }
+    ]
+    names = ["Red Brown Dress"]
+    assert_equal names, BoutiqueInventory.new(items).item_names
+  end
+
+  def test_three_item_names
+    items = [
+      { price: 65.00, name: "Red Brown Dress", quantity_by_size: {} },
+      { price: 50.00, name: "Red Short Skirt", quantity_by_size: {} },
+      { price: 29.99, name: "Black Short Skirt", quantity_by_size: {} }
+    ]
+    names = ["Black Short Skirt", "Red Brown Dress", "Red Short Skirt"]
+    assert_equal names, BoutiqueInventory.new(items).item_names
+  end
+
+  def test_total_stock_for_no_items
+    assert_equal 0, BoutiqueInventory.new([]).total_stock
+  end
+
+  def test_total_stock_for_no_stock
+    shoes = { price: 30.00, name: "Shoes", quantity_by_size: {} }
+    coat = { price: 65.00, name: "Coat", quantity_by_size: {} }
+    items = [shoes, coat]
+    assert_equal 0, BoutiqueInventory.new(items).total_stock
+  end
+
+  def test_total_stock_for_some_items
+    shoes = { price: 30.00, name: "Shoes", quantity_by_size: { s: 1, xl: 4 } }
+    coat = { price: 65.00, name: "Coat", quantity_by_size: {} }
+    handkerchief = { price: 19.99, name: "Handkerchief", quantity_by_size: {} }
+    items = [shoes, coat, handkerchief]
+    assert_equal 5, BoutiqueInventory.new(items).total_stock
+  end
+
+  def test_items_is_an_array_of_ostruct
+    shoes = { price: 30.00, name: "Shoes", quantity_by_size: { s: 1, xl: 4 } }
+    coat = { price: 65.00, name: "Coat", quantity_by_size: { m: 1, l: 2 } }
+    handkerchief = { price: 19.99, name: "Handkerchief", quantity_by_size: { s: 3, m: 2 } }
+    items = [shoes, coat, handkerchief]
+    assert_equal Array, BoutiqueInventory.new(items).items.class
+    assert_equal OpenStruct, BoutiqueInventory.new(items).items.first.class
+  end
+end


### PR DESCRIPTION
## 分報
exercism演習
[ハッシュからOpenStructオブジェクトへの変換](https://exercism.org/tracks/ruby/exercises/boutique-inventory-improvements)
※詳細なアウトプット内容についてはプルリクページ内の"File changed"タブを参照

## 学習したこと

- ハッシュのキーは、OpenStructに変換することでメソッドとして呼び出すことができるようになる

## 学習を通して考えたこと

- railsでよく用いられている「キーをメソッドとして呼び出す」のにはOpenStructオブジェクトを利用することで可能になると学んだ
- 配列には適用できないので、配列の中にあるハッシュは.mapメソッドを利用して各要素それぞれにOpenStruct.new(変数)を用いる必要があると思われる
- 問題演習しただけではハッシュをOpenStructにするメリットがわからなかったので、今後これを用いるときにどちらの方が平易なコードになるか天秤にかけるように臨んでいきたい
