### PR TITLE
exercism演習(頭字語)

### DIFF
--- a/works/november/1121/acronym/README.md
+++ b/works/november/1121/acronym/README.md
@@ -1,0 +1,48 @@
+# Acronym
+
+Welcome to Acronym on Exercism's Ruby Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Convert a phrase to its acronym.
+
+Techies love their TLA (Three Letter Acronyms)!
+
+Help generate some jargon by writing a program that converts a long name like Portable Network Graphics to its acronym (PNG).
+
+Punctuation is handled as follows: hyphens are word separators (like whitespace); all other punctuation can be removed from the input.
+
+For example:
+
+|Input|Output|
+|-|-|
+|As Soon As Possible|ASAP|
+|Liquid-crystal display|LCD|
+|Thank George It's Friday!|TGIF|
+
+## Source
+
+### Created by
+
+- @monkbroc
+
+### Contributed to by
+
+- @bmulvihill
+- @budmc29
+- @cadwallion
+- @hilary
+- @iHiD
+- @Insti
+- @jpotts244
+- @kickinbahk
+- @kotp
+- @kytrinyx
+- @PatrickMcSweeny
+- @pgaspar
+- @tryantwit
+
+### Based on
+
+Julien Vanier - https://github.com/monkbroc

--- a/works/november/1121/acronym/acronym.rb
+++ b/works/november/1121/acronym/acronym.rb
@@ -1,0 +1,15 @@
+class Acronym
+  def self.abbreviate(multi_word)
+    acronym = ""
+    multi_word.split(" ").each do |word|
+      if word.include?("-")
+        word.split("-").each do |word|
+          acronym += word[0].upcase
+        end
+      else
+        acronym += word[0].upcase
+      end
+    end
+  acronym
+  end
+end

--- a/works/november/1121/acronym/acronym_test.rb
+++ b/works/november/1121/acronym/acronym_test.rb
@@ -1,0 +1,40 @@
+require 'minitest/autorun'
+require_relative 'acronym'
+
+class AcronymTest < Minitest::Test
+  def test_basic
+    # skip
+    assert_equal "PNG", Acronym.abbreviate('Portable Network Graphics')
+  end
+
+  def test_lowercase_words
+    skip
+    assert_equal "ROR", Acronym.abbreviate('Ruby on Rails')
+  end
+
+  def test_punctuation
+    skip
+    assert_equal "FIFO", Acronym.abbreviate('First In, First Out')
+  end
+
+  def test_all_caps_word
+    skip
+    assert_equal "GIMP", Acronym.abbreviate('GNU Image Manipulation Program')
+  end
+
+  def test_punctuation_without_whitespace
+    skip
+    assert_equal "CMOS", Acronym.abbreviate('Complementary metal-oxide semiconductor')
+  end
+
+  def test_very_long_abbreviation
+    skip
+    assert_equal "ROTFLSHTMDCOALM",
+      Acronym.abbreviate('Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me')
+  end
+
+  def test_consecutive_delimiters
+    skip
+    assert_equal "SIMUFTA", Acronym.abbreviate('Something - I made up from thin air')
+  end
+end


### PR DESCRIPTION
## 分報

exercism 演習
[**Acronym**](https://exercism.org/tracks/ruby/exercises/acronym)
※詳細なアウトプット内容についてはプルリクページ内の"File changed"タブを参照

## 学習したこと

- .splitで文字列から特定のワードで分割して複数の要素で構成された配列に分割する
- .upcaseで大文字始まりにする(downcaseは逆)

## 学習を通して考えたこと
- 配列の要素をどのように1つの文字列に戻すかにおいて今回はeachを使ってるが、それを使わずともjoinなどで実装できる
- また複数のもので分割する必要がある時(今回は空白とハイフン)は正規表現を用いた方がいい。
- それらを考慮してコードにすると以下のように作れる

~~~ruby
multi_word.split(/\s|-/).map { |word| word[0].upcase }.join
~~~
