### PR TITLE
exercism演習(連続するn桁の数の取得)

### DIFF
--- a/works/november/1124/series/README.md
+++ b/works/november/1124/series/README.md
@@ -1,0 +1,52 @@
+# Series
+
+Welcome to Series on Exercism's Ruby Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a string of digits, output all the contiguous substrings of length `n` in that string in the order that they appear.
+
+For example, the string "49142" has the following 3-digit series:
+
+- "491"
+- "914"
+- "142"
+
+And the following 4-digit series:
+
+- "4914"
+- "9142"
+
+And if you ask for a 6-digit series from a 5-digit string, you deserve whatever you get.
+
+Note that these series are only required to occupy *adjacent positions* in the input;
+the digits need not be *numerically consecutive*.
+
+In this exercise you're practicing iterating over an array, meaning: executing an operation on each element of an array. Ruby has many useful built-in methods for iterations. Take a look at [this article](http://jeromedalbert.com/ruby-how-to-iterate-the-right-way/).
+
+Most of the methods listed in the article are not methods specifically for Array, but come from [Enumerable](https://ruby-doc.org/core/Enumerable.html). The article doesn't list iterating over _consecutive elements_. The first challenge is to find a method that does.
+
+## Source
+
+### Created by
+
+- @kytrinyx
+
+### Contributed to by
+
+- @budmc29
+- @emcoding
+- @hilary
+- @iHiD
+- @Insti
+- @jeporcher
+- @kotp
+- @mikegehard
+- @pgaspar
+- @stevensonmt
+- @tryantwit
+
+### Based on
+
+A subset of the Problem 8 at Project Euler - https://projecteuler.net/problem=8

--- a/works/november/1124/series/series.rb
+++ b/works/november/1124/series/series.rb
@@ -1,0 +1,16 @@
+class Series
+  def initialize(series)
+    @array =[]
+    @series = series
+  end
+
+  def slices(num)
+    raise ArgumentError, 'bad number.' if num <= 0 || num > @series.length
+
+    @array = []
+    for i in 0..(@series.size - num)
+      @array.push(@series.slice(i, num))
+    end
+    @array
+  end
+end

--- a/works/november/1124/series/series_test.rb
+++ b/works/november/1124/series/series_test.rb
@@ -1,0 +1,76 @@
+require 'minitest/autorun'
+require_relative 'series'
+
+class SeriesTest < Minitest::Test
+  def test_slices_of_one_from_one
+    # skip
+    series = Series.new("1")
+    assert_equal ["1"], series.slices(1)
+  end
+
+  def test_slices_of_one_from_two
+    skip
+    series = Series.new("12")
+    assert_equal %w[1 2], series.slices(1)
+  end
+
+  def test_slices_of_two
+    skip
+    series = Series.new("35")
+    assert_equal ["35"], series.slices(2)
+  end
+
+  def test_slices_of_two_overlap
+    skip
+    series = Series.new("9142")
+    assert_equal %w[91 14 42], series.slices(2)
+  end
+
+  def test_slices_can_include_duplicates
+    skip
+    series = Series.new("777777")
+    assert_equal %w[777 777 777 777], series.slices(3)
+  end
+
+  def test_slices_of_a_long_series
+    skip
+    series = Series.new("918493904243")
+    assert_equal %w[91849 18493 84939 49390 93904 39042 90424 04243], series.slices(5)
+  end
+
+  def test_slice_length_is_too_large
+    skip
+    slice_string = "12345"
+    series = Series.new(slice_string)
+    assert_raises ArgumentError do
+      series.slices(6)
+    end
+  end
+
+  def test_slice_length_cannot_be_zero
+    skip
+    slice_string = "12345"
+    series = Series.new(slice_string)
+    assert_raises ArgumentError do
+      series.slices(0)
+    end
+  end
+
+  def test_slice_length_cannot_be_negative
+    skip
+    slice_string = "123"
+    series = Series.new(slice_string)
+    assert_raises ArgumentError do
+      series.slices(-1)
+    end
+  end
+
+  def test_empty_series_is_invalid
+    skip
+    slice_string = ""
+    series = Series.new(slice_string)
+    assert_raises ArgumentError do
+      series.slices(1)
+    end
+  end
+end


### PR DESCRIPTION
## 分報

exercism 演習
[連続するn桁の数の取得](https://exercism.org/tracks/ruby/exercises/series)
※詳細なアウトプット内容についてはプルリクページ内の"File changed"タブを参照

## 学習したこと

- .sliceメソッドで(a,b)で文字列のa番目からb字分だけ切り取る

## 学習を通して考えたこと
- なぜforの範囲が0から@series.size - numまでにしないといけないのか自分では考え付かなかったので以下chatGPTの解説を置きます
~~~
@series = "12345" と num = 3 の場合を考えてみましょう。
@series.size は 5 です。
ループの範囲は 0..(5 - 3) = 0..2 です。
この範囲で生成される部分文字列は "123", "234", "345" です。
このように、ループの範囲を @series.size - num に設定することで、必要なすべての部分文字列を正確に生成できるようになります。
~~~